### PR TITLE
update SoS.tp2，CBSBIN71.tra and  CBSBWT67.tra file

### DIFF
--- a/SoS/SoS.tp2
+++ b/SoS/SoS.tp2
@@ -98,6 +98,10 @@ LANGUAGE ~Italiano (traduzione di Ilot & Co)~
          ~Italian~
          ~SoS/Language/Italian/mod.tra~ ~SoS/Language/Italian/setup.tra~
 
+LANGUAGE ~Simplified Chinese~
+         ~Schinese~
+         ~SoS/Language/Schinese/mod.tra~ ~SoS/Language/Schinese/setup.tra~
+
 /* ====================================== *
  *  Shadows over Soubar : main component  *
  * ====================================== */


### PR DESCRIPTION


Modify the encoding of CBSBIN71.tra and  CBSBWT67.tra file to avoid garbled Chinese characters in the game's dialog.tlk after installation. Add translator information to the tp2 file.